### PR TITLE
Add Mangadex and Manganelo search results sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,11 @@
         "@types/eslint__js": "^8.42.3",
         "cheerio": "^1.0.0",
         "eslint": "^9.21.0",
+        "fastest-levenshtein": "^1.0.16",
         "husky": "^9.1.7",
         "nodemon": "^3.1.9",
         "prettier": "^3.5.2",
+        "stemmer": "^2.0.1",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.24.1"
       }
@@ -2859,6 +2861,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.0",
@@ -7229,6 +7241,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/stemmer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stemmer/-/stemmer-2.0.1.tgz",
+      "integrity": "sha512-bkWvSX2JR4nSZFfs113kd4C6X13bBBrg4fBKv2pVdzpdQI2LA5pZcWzTFNdkYsiUNl13E4EzymSRjZ0D55jBYg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "stemmer": "cli.js"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "@types/eslint__js": "^8.42.3",
     "cheerio": "^1.0.0",
     "eslint": "^9.21.0",
+    "fastest-levenshtein": "^1.0.16",
     "husky": "^9.1.7",
     "nodemon": "^3.1.9",
     "prettier": "^3.5.2",
+    "stemmer": "^2.0.1",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.1"
   }

--- a/src/MangaDex/main.ts
+++ b/src/MangaDex/main.ts
@@ -606,6 +606,7 @@ export class MangaDexExtension implements MangaDexImplementation {
       json.data,
       COVER_BASE_URL,
       getSearchThumbnail,
+      query,
     );
     const nextMetadata: MangaDex.Metadata | undefined =
       results.length < 100 ? undefined : { offset: offset + 100 };

--- a/src/MangaDex/pbconfig.ts
+++ b/src/MangaDex/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceIntents } from "@paperback/types";
 export default {
   icon: "icon.png",
   name: "MangaDex",
-  version: "1.0.0-alpha.1",
+  version: "1.0.0-alpha.2",
   description: "The mangadex.org extension.",
   contentRating: ContentRating.MATURE,
   developers: [

--- a/src/Manganelo/pbconfig.ts
+++ b/src/Manganelo/pbconfig.ts
@@ -3,7 +3,7 @@ import { ContentRating, SourceInfo, SourceIntents } from "@paperback/types";
 export default {
   name: "Manganelo",
   description: "Extension that pulls content from m.manganelo.com.",
-  version: "1.0.0-alpha.1",
+  version: "1.0.0-alpha.2",
   icon: "icon.png",
   language: "en",
   contentRating: ContentRating.EVERYONE,

--- a/src/utils/titleRelevanceScore.ts
+++ b/src/utils/titleRelevanceScore.ts
@@ -1,0 +1,196 @@
+import { distance as levenshtein } from "fastest-levenshtein";
+import { stemmer } from "stemmer";
+
+export const relevanceScore = (title: string, queryTitle: string): number => {
+  /**
+   * Calculates the relevance score between a given `title` and a `queryTitle` using a comprehensive set of string matching techniques.
+   * The scoring system prioritizes exact matches but also considers partial similarities to provide a nuanced relevance metric.
+   *
+   * 100: Exact match of title and query after stripping and tokenization.
+   * 100: Exact phrase match at the beginning of the title.
+   * 95: Exact phrase match elsewhere in the title.
+   * 90: Adjacent sequence match at the beginning.
+   * 85: Adjacent sequence match elsewhere.
+   * 80: Query words appear in order but not adjacent.
+   * 75: All query words are present regardless of order.
+   * Below 70: Partial matches, with similarity calculated.
+   *
+   * @param title - The first input number
+   * @param queryTitle - The second input number
+   * @returns a number representing the relevance score
+   */
+  const titleTokens = tokenize(title);
+  const queryTokens = tokenize(queryTitle);
+
+  const titleWords = stemmedTokens(titleTokens);
+  const queryWords = stemmedTokens(queryTokens);
+
+  const titleStripped = titleWords.join("");
+  const queryStripped = queryWords.join("");
+
+  // Exact match after stemming
+  if (titleStripped === queryStripped) {
+    return 100;
+  }
+
+  const titlePhrase = titleWords.join(" ");
+  const queryPhrase = queryWords.join(" ");
+
+  // Exact phrase match at beginning after stemming
+  const phraseAtStartRegex = new RegExp(`^${queryPhrase}\\b`, "i");
+  if (phraseAtStartRegex.test(titlePhrase)) {
+    return 95;
+  }
+
+  // Exact phrase match anywhere after stemming
+  const phraseAnywhereRegex = new RegExp(`\\b${queryPhrase}\\b`, "i");
+  if (phraseAnywhereRegex.test(titlePhrase)) {
+    return 90;
+  }
+
+  // **All query words present regardless of order**
+  if (allWordsPresent(titleWords, queryWords)) {
+    if (wordsAppearInOrder(titleWords, queryWords)) {
+      return 90; // All words present and in order
+    } else if (wordsAppearInReverseOrder(titleWords, queryWords)) {
+      return 85; // All words present in reverse order
+    } else {
+      return 80; // All words present in any order
+    }
+  }
+
+  // Words appear in order but not adjacent
+  if (wordsAppearInOrder(titleWords, queryWords)) {
+    return 80;
+  }
+
+  // Partial matches
+  const matchedQueryWords = getMatchedQueryWordsCount(titleWords, queryWords);
+  const proportionMatched = matchedQueryWords / queryWords.length;
+
+  let totalSimilarity = 0;
+  for (const queryWord of queryWords) {
+    let maxSimilarity = 0;
+    for (const titleWord of titleWords) {
+      const similarity = wordSimilarity(queryWord, titleWord);
+      if (similarity > maxSimilarity) {
+        maxSimilarity = similarity;
+      }
+    }
+    totalSimilarity += maxSimilarity;
+  }
+  const averageSimilarity = totalSimilarity / queryWords.length;
+  const finalScore = averageSimilarity * 70 * proportionMatched; // Scale appropriately
+  return Math.max(0, Math.min(70, finalScore));
+};
+
+// Sanitize and split text into tokens/words
+const tokenize = (text: string): string[] => {
+  return text
+    .toLowerCase()
+    .replace(/[\u2019']/g, "") // Remove apostrophes
+    .replace(/[^\w\s-]/g, "") // Remove punctuation except hyphens
+    .split(/[\s-_]+/) // Split into words on spaces or hyphens or underscores
+    .filter((word) => word.length > 0);
+};
+
+const stemmedTokens = (tokens: string[]): string[] => {
+  return tokens.map((word) => stemmer(word));
+};
+
+const getMatchedQueryWordsCount = (
+  titleWords: string[],
+  queryWords: string[],
+): number => {
+  let count = 0;
+  for (const queryWord of queryWords) {
+    for (const titleWord of titleWords) {
+      if (wordSimilarity(queryWord, titleWord) >= 0.7) {
+        count++;
+        break;
+      }
+    }
+  }
+  return count;
+};
+
+const wordsAppearInOrder = (
+  titleWords: string[],
+  queryWords: string[],
+): boolean => {
+  let titleIndex = 0;
+  for (let i = 0; i < queryWords.length; i++) {
+    const queryWord = queryWords[i];
+    while (titleIndex < titleWords.length) {
+      if (wordSimilarity(queryWord, titleWords[titleIndex]) >= 0.7) {
+        // Match found
+        titleIndex++;
+        break;
+      }
+      titleIndex++;
+    }
+    if (titleIndex === titleWords.length && i < queryWords.length - 1) {
+      // Not all words found in order
+      return false;
+    }
+  }
+  return true;
+};
+
+const wordsAppearInReverseOrder = (
+  titleWords: string[],
+  queryWords: string[],
+): boolean => {
+  const reversedQueryWords = [...queryWords].reverse();
+  return wordsAppearInOrder(titleWords, reversedQueryWords);
+};
+
+const allWordsPresent = (
+  titleWords: string[],
+  queryWords: string[],
+): boolean => {
+  for (const queryWord of queryWords) {
+    let found = false;
+    for (const titleWord of titleWords) {
+      if (wordSimilarity(queryWord, titleWord) >= 0.7) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      // Word not found in title
+      return false;
+    }
+  }
+  return true;
+};
+
+// Get word similarity between two words
+const wordSimilarity = (word1: string, word2: string): number => {
+  const stemmedWord1 = stemmer(word1);
+  const stemmedWord2 = stemmer(word2);
+
+  // Direct match after stemming
+  if (stemmedWord1 === stemmedWord2) {
+    return 1.0;
+  }
+
+  // **Substring Match Check**
+  if (
+    stemmedWord1.includes(stemmedWord2) ||
+    stemmedWord2.includes(stemmedWord1)
+  ) {
+    return 0.8; // Fixed similarity score for substring matches
+  }
+
+  // Levenshtein distance
+  const maxLen = Math.max(stemmedWord1.length, stemmedWord2.length);
+  const distance = levenshtein(stemmedWord1, stemmedWord2);
+  const similarity = (maxLen - distance) / maxLen;
+
+  if (similarity >= 0.6) {
+    return similarity;
+  }
+
+  return 0;
+};


### PR DESCRIPTION
The search results for some extensions aren't sorted by relevance so may require browsing to find what you're searching for. This fixes that.
![IMG_5312](https://github.com/user-attachments/assets/bf43ba6a-db64-47ab-ae59-5064f9a5f660)